### PR TITLE
fix(BinaryLogClient): query for session 'binlog_checksum' rather than global

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -674,7 +674,7 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     private ChecksumType fetchBinlogChecksum() throws IOException {
-        channel.write(new QueryCommand("show global variables like 'binlog_checksum'"));
+        channel.write(new QueryCommand("show variables like 'binlog_checksum'"));
         ResultSetRowPacket[] resultSet = readResultSet();
         if (resultSet.length == 0) {
             return ChecksumType.NONE;


### PR DESCRIPTION
Fixes https://github.com/fivetran/app/issues/23941

For Percona Clusters, slaves do not have access to the `performance_schema` and cannot run `show global variables like 'binlog_checksum'.` It does, however, have access to the session variable in `show variables like 'binlog_checksum'`. 

Because session variables inherit the global variable default (and because we don't override this session variable), this fix should work for all mysql connections (I'll test this feature for each mysql variant before releasing it to all customers)