### PR TITLE
Fix abortRequest to reset upon a new connection

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -928,6 +928,7 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     private void listenForEventPackets(final PacketChannel channel) throws IOException {
         ByteArrayInputStream inputStream = channel.getInputStream();
         boolean completeShutdown = false;
+        abortRequest = false;
         try {
             while (!abortRequest && inputStream.peek() != -1) {
                 int packetLength = inputStream.readInteger(3);


### PR DESCRIPTION
I added abortRequest as a field, so currently, if you abort once, that client will never be able to read packets again. This resets the abortRequest field before the listenForEventPackets main loop