### PR TITLE
move change from connector to binlog client

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -905,7 +905,7 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     protected ChecksumType fetchBinlogChecksum(final PacketChannel channel) throws IOException {
-        channel.write(new QueryCommand("show global variables like 'binlog_checksum'"));
+        channel.write(new QueryCommand("show variables like 'binlog_checksum'"));
         ResultSetRowPacket[] resultSet = readResultSet(channel);
         if (resultSet.length == 0) {
             return ChecksumType.NONE;


### PR DESCRIPTION
https://fivetran.atlassian.net/browse/RD-299681

We have a class in the Fivetran connector code that extends BinaryLogClient and has this one override, but we use this extended class everywhere. Adding it to BinaryLogClient here so that we can get rid of signature changes between the older client and the osheroff rebase one. 