### PR TITLE
add client identity method

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -168,6 +168,10 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
         this.password = password;
     }
 
+    public String fivetranClientIdentity() {
+        return "mysql-binlog-connector-java";
+    }
+
     public boolean isBlocking() {
         return blocking;
     }


### PR DESCRIPTION
Adds an identity method to this client temporarily so that, during the time we have 2 in rotation, we can log which binary log client we're using.